### PR TITLE
Add Wager Summary Modal

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,31 @@
+'use client';
+
 import Welcome from '@/components/atoms/welcome';
 import { GameOptions } from '@/components/organisms/game-mode-selection';
+import { useModalStore } from '@/store/modal-store';
+import { GameModal } from '@/components/organisms/game-modal';
+import { WagerSummaryModal } from '@/components/organisms/WagerSummaryModal';
 
 export default function Home() {
+  const { openModal } = useModalStore();
+
+  const handleGameSelect = (gameId: string) => {
+    if (gameId === 'quick-game') {
+      openModal('game');
+    } else if (gameId === 'single-player') {
+      openModal('wager');
+    }
+    // Add handlers for other game types as needed
+  };
+
   return (
     <main className="lg:max-w-[53rem] mt-4 mx-auto h-fit w-full mb-20 lg:mb-12 p-4 lg:p-0 md:mt-24 lg:mt-32">
       <Welcome />
-      <GameOptions />
+      <GameOptions onSelectGame={handleGameSelect} />
+      
+      {/* Modals */}
+      <GameModal />
+      <WagerSummaryModal />
     </main>
   );
 }

--- a/src/components/organisms/WagerSummaryModal.tsx
+++ b/src/components/organisms/WagerSummaryModal.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Modal } from './modal';
+import { InfoIcon } from 'lucide-react';
+import { useState } from 'react';
+import { useModalStore } from '@/store/modal-store';
+
+export function WagerSummaryModal() {
+  const { isOpen, modalType, closeModal } = useModalStore();
+  const [genre] = useState('Hip Hop');
+  const [difficultyLevel] = useState('Expert');
+  const [duration] = useState('10 Mins');
+  const [odds] = useState('10 odds (get everything right)');
+  const [wagerAmount] = useState('10,000 STRK (100 USD)');
+  const [winAmount] = useState('80,000 STRK (800 USD)');
+
+  const handleStartGame = () => {
+    closeModal();
+    // Start game logic would go here
+    console.log('Starting wager game...');
+  };
+
+  const isModalOpen = isOpen && modalType === 'wager';
+
+  const modalContent = (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vulputate libero et velit interdum.
+      </p>
+      
+      <div className="space-y-3">
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">Genre</span>
+          <span className="font-medium">{genre}</span>
+        </div>
+        
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">Difficulty Level</span>
+          <span className="font-medium">{difficultyLevel}</span>
+        </div>
+        
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">Duration</span>
+          <span className="font-medium">{duration}</span>
+        </div>
+        
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">Odds</span>
+          <span className="font-medium">{odds}</span>
+        </div>
+        
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">Wager Amount</span>
+          <span className="font-medium">{wagerAmount}</span>
+        </div>
+        
+        <div className="flex justify-between items-center">
+          <span className="text-gray-600">You Win</span>
+          <span className="font-medium text-purple-600">{winAmount}</span>
+        </div>
+      </div>
+      
+      <div className="bg-purple-50 p-4 rounded-lg flex gap-3">
+        <div className="bg-purple-100 rounded-full p-1 h-6 w-6 flex items-center justify-center flex-shrink-0 text-purple-600">
+          <InfoIcon />
+        </div>
+        <div className="text-sm">
+          <h4 className="font-medium text-purple-700 mb-1">INSTRUCTION</h4>
+          <p className="text-gray-700">
+            A card displaying a lyric from a song will appear along with a list of possible answers. Your goal according to the odd you picked is to get 80% of the lyrics presented you.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <Modal
+      isOpen={isModalOpen}
+      onClose={closeModal}
+      title="Wager Summary"
+      primaryActionLabel="Start Game"
+      onPrimaryAction={handleStartGame}
+      bgColor="bg-white"
+      children={modalContent}
+    />
+  );
+} 


### PR DESCRIPTION
Added a new WagerSummaryModal component to display wager details and added support for the wager modal type in the modal store.
Changes
Created new WagerSummaryModal component that shows wager details and instructions
Updated modal store to support 'wager' type
Updated Home page to show the wager modal when users click on the Single Player wager option
Fixed styling for modal components
Added TypeScript error handling with appropriate comments
Implementation Details
The WagerSummaryModal component displays:
Genre, difficulty level, duration information
Odds, wager amount, and potential winnings
Instructions for the game in a highlighted section
Start Game button to begin the wager
Modal styling resembles the provided design with a clean white background and purple accents.
Closes #27